### PR TITLE
Link styling fix

### DIFF
--- a/nebula-components/base/_scaffolding.scss
+++ b/nebula-components/base/_scaffolding.scss
@@ -7,6 +7,7 @@ body {
 
 a {
   color: $nb-color-link;
+  text-decoration-skip: ink;
 
   &:hover,
   &:focus {


### PR DESCRIPTION
Fixed on the link as per story #25 - perhaps a class maybe better as other elements may have this styling? Screenshots here:

![screen shot 2017-09-14 at 17 17 29](https://user-images.githubusercontent.com/11405108/30441441-5a443d3a-9971-11e7-9f2b-899b2793bd65.png)

Hover:
![screen shot 2017-09-14 at 17 18 38](https://user-images.githubusercontent.com/11405108/30441442-5a455990-9971-11e7-9d74-aad5d3fea971.png)
